### PR TITLE
SSLv3 check

### DIFF
--- a/asio/include/asio/ssl/impl/context.ipp
+++ b/asio/include/asio/ssl/impl/context.ipp
@@ -84,6 +84,7 @@ context::context(context::method m)
     handle_ = ::SSL_CTX_new(::SSLv2_server_method());
     break;
 #endif // defined(OPENSSL_NO_SSL2)
+#if !defined(OPENSSL_NO_SSL3_METHOD)
   case context::sslv3:
     handle_ = ::SSL_CTX_new(::SSLv3_method());
     break;
@@ -93,6 +94,7 @@ context::context(context::method m)
   case context::sslv3_server:
     handle_ = ::SSL_CTX_new(::SSLv3_server_method());
     break;
+#endif // !defined(OPENSSL_NO_SSL3_METHOD)
   case context::tlsv1:
     handle_ = ::SSL_CTX_new(::TLSv1_method());
     break;


### PR DESCRIPTION
Added check to avoid trying to use deprecated SSLv3 in context.impl
